### PR TITLE
chore(web-test): add link to geo locations docs

### DIFF
--- a/modules/web-test/variables.tf
+++ b/modules/web-test/variables.tf
@@ -66,7 +66,7 @@ variable "timeout" {
 }
 
 variable "geo_locations" {
-  description = "A list of physical locations to run this Web Test."
+  description = "A list of physical locations to run this Web Test." # Complete list of Azure locations: https://learn.microsoft.com/nb-no/previous-versions/azure/azure-monitor/app/monitor-web-app-availability#azure
   type        = list(string)
 
   default = [


### PR DESCRIPTION
Added link to Microsoft documentation in the description for `geo-locations`-variable, which provide a complete list of the [Azure location population tags](https://learn.microsoft.com/nb-no/previous-versions/azure/azure-monitor/app/monitor-web-app-availability#azure) availiable.

