### PR TITLE
docs: include SECURITY.md to the repo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# SECURITY
+
+If you discover a security vulnerability in this project, please follow the steps below to report it.
+
+## For "non-critical" issues
+
+Create a GitHub issue for the vulnerability and ask the maintainer to reach our to you. Avoid putting sensitive information in the issue.
+
+### For "critical" and time sensitive issues
+
+Send email to [it-security@equinor.com](mailto:it-security@equinor.com) or​ phone the Equinor helpdesk:
+
+- Norway (+47) 51 999 222
+- US/Canada (+1) 713 878 6970

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
-# Security guidelines
+# Security policy
 
-This project has adopted the [Equinor Terraform Baseline security guidelines](https://github.com/equinor/terraform-baseline/blob/main/SECURITY.md).
+This project has adopted the [Equinor Terraform Baseline security policy](https://github.com/equinor/terraform-baseline/blob/main/SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,3 @@
-# SECURITY
+# Security guidelines
 
-If you discover a security vulnerability in this project, please follow the steps below to report it.
-
-## For "non-critical" issues
-
-Create a GitHub issue for the vulnerability and ask the maintainer to reach our to you. Avoid putting sensitive information in the issue.
-
-### For "critical" and time sensitive issues
-
-Send email to [it-security@equinor.com](mailto:it-security@equinor.com) or​ phone the Equinor helpdesk:
-
-- Norway (+47) 51 999 222
-- US/Canada (+1) 713 878 6970
+This project has adopted the [Equinor Terraform Baseline security guidelines](https://github.com/equinor/terraform-baseline/blob/main/SECURITY.md).


### PR DESCRIPTION
Include SECURITY.md to the Repository to keep up with the current policies for source code management (SCM) system usage in Equinor.