### PR TITLE
fix: bump required AzAPI provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     azapi = {
       source  = "azure/azapi"
-      version = ">= 1.0.0"
+      version = ">= 2.0.0"
     }
   }
 }


### PR DESCRIPTION
Changes introduced in #50 required AzAPI provider v2. 